### PR TITLE
arch: build for riscv64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           - {"name": "tempio_armhf", "args": "GOARM=6 GOARCH=arm"}
           - {"name": "tempio_armv7", "args": "GOARM=7 GOARCH=arm"}
           - {"name": "tempio_aarch64", "args": "GOARCH=arm64"}
+          - {"name": "tempio_riscv64", "args": "GOARCH=riscv64"}
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Go supports riscv, so I propose to also build for this architecture.

Builds and tests pass on my risc-v Ubuntu 24.04.1 HiFive Unmatched board.