### PR TITLE
Replace deprecated ioutil with os functions

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 )
@@ -29,7 +28,7 @@ func readConfigPipe() *map[string]interface{} {
 }
 
 func readConfigFile(file string) *map[string]interface{} {
-	configFile, err := ioutil.ReadFile(file)
+	configFile, err := os.ReadFile(file)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 )
 
 var TempioVersion string
@@ -38,7 +38,7 @@ func main() {
 	if *outFile == "" {
 		fmt.Println(string(data))
 	} else {
-		err := ioutil.WriteFile(*outFile, data, 0644)
+		err := os.WriteFile(*outFile, data, 0644)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/template.go
+++ b/template.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"log"
+	"os"
 	"text/template"
 
 	sprig "github.com/Masterminds/sprig/v3"
@@ -11,7 +11,7 @@ import (
 
 func renderTemplateFile(config *map[string]interface{}, file string) []byte {
 	// read Template
-	templateFile, err := ioutil.ReadFile(file)
+	templateFile, err := os.ReadFile(file)
 	if err != nil {
 		log.Fatalf("Cant read template file %s - %s", file, err)
 	}


### PR DESCRIPTION
Stop using the deprecated ioutil package and replace function calls with the variants from the os package.