### PR TITLE
Drop unused golang-lint version variable

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,9 +6,6 @@ on:
       - main
   pull_request:
 
-env:
-  GOLANG_LINT_VERSION: "v1.51.2"
-
 jobs:
   golangci:
     name: Lint


### PR DESCRIPTION
With the move to Go 1.21 the latest version is used always. Drop the unnecessary environment variable.