### PR TITLE
Enable errcheck and stylecheck linters

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,3 @@ jobs:
         uses: golangci/golangci-lint-action@v6.1.1
         with:
           version: latest
-          args: -D errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+linters:
+  enable:
+    - stylecheck

--- a/main_test.go
+++ b/main_test.go
@@ -7,21 +7,21 @@ import (
 )
 
 func TestTemplatesJoin(t *testing.T) {
-	dataJson := []byte(`{"list": ["hallo", "welt", "bla"]}`)
+	dataJSON := []byte(`{"list": ["hallo", "welt", "bla"]}`)
 	dataTemplate := []byte(`{{ join ";" .list }}`)
 
-	test_config := readConfigBuffer(dataJson)
-	rendered := renderTemplateBuffer(test_config, dataTemplate)
+	testConfig := readConfigBuffer(dataJSON)
+	rendered := renderTemplateBuffer(testConfig, dataTemplate)
 
 	assert.Equal(t, string(rendered), "hallo;welt;bla")
 }
 
 func TestTemplatesCalc(t *testing.T) {
-	dataJson := []byte(`{"num": 3}`)
+	dataJSON := []byte(`{"num": 3}`)
 	dataTemplate := []byte(`{{ add .num 3 }}-{{ mul .num 3 }}`)
 
-	test_config := readConfigBuffer(dataJson)
-	rendered := renderTemplateBuffer(test_config, dataTemplate)
+	testConfig := readConfigBuffer(dataJSON)
+	rendered := renderTemplateBuffer(testConfig, dataTemplate)
 
 	assert.Equal(t, string(rendered), "6-9")
 }


### PR DESCRIPTION
It seems that errcheck actually runs through fine, so reenable this linter. Also enable the stylecheck linter and fix a few findings.