### PR TITLE
Add macOS (darwin) build targets for ARM64 and AMD64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
           - {"name": "tempio_armhf", "args": "GOARM=6 GOARCH=arm"}
           - {"name": "tempio_armv7", "args": "GOARM=7 GOARCH=arm"}
           - {"name": "tempio_aarch64", "args": "GOARCH=arm64"}
+          - {"name": "tempio_darwin_amd64", "args": "GOOS=darwin GOARCH=amd64"}
+          - {"name": "tempio_darwin_arm64", "args": "GOOS=darwin GOARCH=arm64"}
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Summary
  - Add `tempio_darwin_arm64` build variant for macOS on Apple Silicon
  - Add `tempio_darwin_amd64` build variant for macOS on Intel

## Details
- Cross-compilation from Ubuntu runner using GOOS=darwin with CGO_ENABLED=0 — no additional dependencies or runner changes required.
- This resolves the zsh: exec format error when attempting to run Linux binaries on macOS.
- Verified local build on macOS ARM64 (Apple Silicon) — binary produced and runs correctly   
```
❯ ./tempio_darwin_arm64 --help
Version: 
Documentation: https://github.com/home-assistant/tempio

  -conf string
        Config json file, can be omitted if used in a pipe
  -out string
        Output file, if not defined output will be to console
  -template string
        Template file
```