### PR TITLE
Update Go to 1.25

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "TempIO",
-	"image": "mcr.microsoft.com/vscode/devcontainers/go:1.23",
+	"image": "mcr.microsoft.com/vscode/devcontainers/go:1.25",
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 	"customizations": {
 		"vscode": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     branches: ["main"]
 
 env:
-  GOLANG_VERSION: "1.23"
+  GOLANG_VERSION: "1.25"
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANG_VERSION: "1.23"
+  GOLANG_VERSION: "1.25"
 
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-assistant/tempio
 
-go 1.23
+go 1.25
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
Update Go to 1.25 (as that's version we currently use in HAOS and for other Go-based projects in the org).

Closes #118