### PR TITLE
workflows: build: give contents write permissions to github token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build ${{ matrix.variant.name }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     strategy:
       matrix:
         variant:


### PR DESCRIPTION
Update build.yml to specify 'contents: write' permission needed by shogo82148/actions-upload-release-asset to upload files properly. The alternative for personal GitHub accounts is to set additional write permissions for all workflows; this is not an option on organization GitHub accounts. With this applied the settings/actions/"Workflow permissions" may remain as selected "Read repository contents and packages permissions" instead of the more permissive "Read and write permissions" where available.