### PR TITLE
Add build target for RISC-V

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           - {"name": "tempio_armhf", "args": "GOARM=6 GOARCH=arm"}
           - {"name": "tempio_armv7", "args": "GOARM=7 GOARCH=arm"}
           - {"name": "tempio_aarch64", "args": "GOARCH=arm64"}
+          - {"name": "tempio_riscv64", "args": "GOARCH=riscv64"}
           - {"name": "tempio_darwin_amd64", "args": "GOOS=darwin GOARCH=amd64"}
           - {"name": "tempio_darwin_arm64", "args": "GOOS=darwin GOARCH=arm64"}
     steps:


### PR DESCRIPTION
## Summary
  - Add `tempio_riscv64` build variant

## Details
- Cross-compilation from Ubuntu runner using GOARCH=riscv64 — no additional dependencies or runner changes required.
- This resolves the zsh: exec format error when attempting to run riscv64 Linux binaries.
- Verified local build on Debian Linux 13 Trixie (StarFive JH-7110) — binary produced and runs correctly
```
❯ ./tempio_riscv64 --help
Version: 
Documentation: https://github.com/home-assistant/tempio

  -conf string
        Config json file, can be omitted if used in a pipe
  -out string
        Output file, if not defined output will be to console
  -template string
        Template file
```

References to earlier PR and issues:
Jul 4, 2024 [Supported boards/hardware/machines: riscv64](https://github.com/home-assistant/architecture/discussions/1107)
Nov 11, 2024 [arch: build for riscv64](https://github.com/home-assistant/tempio/pull/75)  <-- Resubmitting with re-base to origin/main
Mar 7, 2025 [want to compile a risv64 version of tempio](https://github.com/home-assistant/tempio/issues/93)
Mar 22, 2026 [Add macOS (darwin) build targets for ARM64 and AMD64](https://github.com/home-assistant/tempio/pull/121)

Please consider this re-submission of PR #75 as the other PR that was merged recently is similar, we are each developing for Home Assistant locally on our preferred platforms not necessarily as a supported ADR'ed platform.