### PR TITLE
workflows: build: use gh CLI to upload release assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,6 @@ jobs:
 
     - name: Upload release asset
       if: github.event_name == 'release'
-      uses: shogo82148/actions-upload-release-asset@v1
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: "${{ github.workspace }}/${{ matrix.variant.name }}"
-        asset_name: ${{ matrix.variant.name }}
-        asset_content_type: application/x-binary
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release upload "${{ github.event.release.tag_name }}" "${{ matrix.variant.name }}" --clobber


### PR DESCRIPTION
Follow-up to #124.

Replaces the third-party `shogo82148/actions-upload-release-asset` action with the first-party GitHub CLI (`gh release upload`), which is pre-installed on the runners.

### Why
- Removes a third-party action dependency (no tag/SHA to pin or trust).
- Matches the approach other Home Assistant repos have moved to — e.g. `frontend` and `android` both use `gh release upload ... --clobber`.
- `--clobber` makes re-runs idempotent (overwrites an existing asset instead of failing).

The `contents: write` permission added in #124 is still required and stays in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)