### PR TITLE
Bump Go to 1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     branches: ["main"]
 
 env:
-  GOLANG_VERSION: "1.25"
+  GOLANG_VERSION: "1.26"
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  GOLANG_VERSION: "1.25"
+  GOLANG_VERSION: "1.26"
 
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-assistant/tempio
 
-go 1.25
+go 1.26
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
Update the Go toolchain to 1.26 in go.mod and the CI workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)